### PR TITLE
Fixed padding of the role labels.

### DIFF
--- a/resources/ts/pages/dashboard/ns-permissions.vue
+++ b/resources/ts/pages/dashboard/ns-permissions.vue
@@ -16,7 +16,7 @@
                         </button>
                     </div>
                 </div>
-                <div :key="permission.id" v-for="permission of filteredPermissions" :class="toggled ? 'w-24' : 'w-54'" class="p-2 border-b border-gray-700 text-gray-100">
+                <div :key="permission.id" v-for="permission of filteredPermissions" :class="toggled ? 'w-24' : 'w-54'" class="p-3 border-b border-gray-700 text-gray-100">
                     <a @click="copyPermisson( permission.namespace )" href="javascript:void(0)" :title="permission.namespace">
                         <span v-if="! toggled">{{ permission.name }}</span>
                         <span v-if="toggled">{{ permission.name }}</span>


### PR DESCRIPTION
This pull request addresses an issue with the alignment of user divs in the permissions section. The padding of the permission labels has been adjusted to ensure that the user divs are properly aligned in front of each row. This improvement enhances the overall readability and visual structure of the permissions layout, providing a cleaner and more user-friendly interface.