### PR TITLE
Fix bug in unit group edit page

### DIFF
--- a/app/Crud/UnitGroupCrud.php
+++ b/app/Crud/UnitGroupCrud.php
@@ -29,7 +29,7 @@ class UnitGroupCrud extends CrudService
     /**
      * base route name
      */
-    protected $mainRoute = 'ns.units-groups';
+    protected $mainRoute = 'units/groups';
 
     /**
      * Define namespace
@@ -281,7 +281,7 @@ class UnitGroupCrud extends CrudService
             identifier: 'edit',
             label: __( 'Edit' ),
             type: 'GOTO',
-            url: ns()->url( '/dashboard/' . 'units' . '/edit/' . $entry->id )
+            url: ns()->url( '/dashboard/units/groups/edit/' . $entry->id )
         );
 
         // Snippet 2
@@ -289,7 +289,7 @@ class UnitGroupCrud extends CrudService
             identifier: 'delete',
             label: __( 'Delete' ),
             type: 'DELETE',
-            url: ns()->url( '/api/crud/ns.units/' . $entry->id ),
+            url: ns()->url( '/api/crud/ns.units-groups/' . $entry->id ),
             confirm: [
                 'message' => __( 'Would you like to delete this ?' ),
             ]

--- a/routes/api/units.php
+++ b/routes/api/units.php
@@ -18,3 +18,4 @@ Route::put( 'units-groups/{id}', [ UnitsController::class, 'putGroup' ] );
 Route::put( 'units/{id}', [ UnitsController::class, 'putUnit' ] );
 
 Route::get( 'units-groups/{id}/units', [ UnitsController::class, 'getGroupUnits' ] );
+Route::get( 'units/groups/edit/{group}', [ UnitsController::class, 'editUnitGroup' ] ); // P8956


### PR DESCRIPTION
Related to #1986

Fix the issue with the edit unit group page not displaying correctly.

* **Correct URL paths in `app/Crud/UnitGroupCrud.php`**
  - Update `mainRoute` property to `'units/groups'`
  - Update `namespace` property to `'ns.units-groups'`
  - Update `edit` action URL in `setActions` method to `ns()->url('/dashboard/units/groups/edit/' . $entry->id)`
  - Update `delete` action URL in `setActions` method to `ns()->url('/api/crud/ns.units-groups/' . $entry->id)`

* **Add new route in `routes/api/units.php`**
  - Add route for editing unit groups: `Route::get('units/groups/edit/{group}', [UnitsController::class, 'editUnitGroup']);`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Blair2004/NexoPOS/issues/1986?shareId=74065aca-325b-4219-b54b-a58fa825d616).