### PR TITLE
fix(pos): barcode scan crashes when unit/unitQuantity is null

### DIFF
--- a/resources/ts/pages/dashboard/pos/ns-pos-grid.vue
+++ b/resources/ts/pages/dashboard/pos/ns-pos-grid.vue
@@ -413,12 +413,19 @@ export default {
                             product.rate                    =   result.product.rate;
                             product.tax_group_id            =   result.product.tax_group_id;
                             product.tax_type                =   result.product.tax_type;
-                            product.unit_id                 =   result.unit.id;
-                            product.unit_price              =   result.unitQuantity.sale_price;
-                            product.price_gross             =   result.unitQuantity.sale_price_gross;
-                            product.price_net               =   result.unitQuantity.sale_price_net;
-                            product.unit_name               =   result.unit.name;
-                            product.unitQuantity            =   result.unitQuantity;
+                            product.stock_management        =   result.product.stock_management;
+                            product.type                    =   result.product.type;
+                            
+                            // Use result.unit/unitQuantity if set, otherwise fall back to first unit_quantity
+                            const uq = result.unitQuantity || (result.product.unit_quantities && result.product.unit_quantities[0]);
+                            const unit = result.unit || (uq && uq.unit);
+                            
+                            product.unit_id                 =   unit?.id || uq?.unit_id;
+                            product.unit_price              =   uq?.sale_price;
+                            product.price_gross             =   uq?.sale_price_gross;
+                            product.price_net               =   uq?.sale_price_net;
+                            product.unit_name               =   unit?.name || '';
+                            product.unitQuantity            =   uq;
                             
                             // Check if this is a scale barcode with embedded data
                             if ( result.scale ) {
@@ -433,7 +440,7 @@ export default {
                                     product.quantity = scaleData.value;
                                     
                                     // Show notification with unit name
-                                    const unitName = scaleData.unit?.name || 'kg';
+                                    const unitName = result.unit?.name || (uq && uq.unit && uq.unit.name) || '';
                                     nsSnackBar.info( 
                                         __( 'Scale barcode detected: {weight} {unit}' )
                                             .replace( '{weight}', scaleData.value.toFixed(3) )
@@ -442,8 +449,7 @@ export default {
                                 } else if ( scaleData.type === 'price' ) {
                                     // For price-based scales, we need to calculate quantity
                                     // based on the price and unit price
-                                    const unitPrice = result.product.selectedUnitQuantity?.sale_price || 
-                                                     result.product.unit_quantities[0]?.sale_price || 0;
+                                    const unitPrice = uq?.sale_price || 0;
                                     if ( unitPrice > 0 ) {
                                         product.quantity = scaleData.value / unitPrice;
                                     }


### PR DESCRIPTION
## Files Changed

**1 file**: ns-pos-grid.vue

---

## Problem

The POS barcode field (`/api/products/search/using-barcode/{value}`) has **4 search paths** to find a product by barcode:

| Path | Match Source | `result.unit` set? | `result.unitQuantity` set? |
|------|-------------|-------------------|--------------------------|
| 1 | Scale barcode (PLU) | ✅ Yes | ✅ Yes |
| 2 | Procurement product barcode | ❌ **null** | ❌ **null** |
| 3 | Product unit_quantity barcode | ✅ Yes | ✅ Yes |
| 4 | Direct product barcode | ❌ **null** | ❌ **null** |

On paths 2 and 4, the frontend crashes:

```js
product.unit_id    = result.unit.id;              // TypeError: Cannot read properties of null
product.unit_price = result.unitQuantity.sale_price;  // TypeError
product.price_gross = result.unitQuantity.sale_price_gross;
product.price_net  = result.unitQuantity.sale_price_net;
product.unit_name  = result.unit.name;
```

**Additionally**, two silent bugs existed even on paths that worked:

1. Products added via barcode bypassed stock validation because `stock_management` and `type` fields were never mapped into the product object — `ProductQuantityPromise` checked `product.$original().stock_management === 'enabled'` which was always `undefined`

2. Scale barcode notifications always displayed `'kg'` because they read `scaleData.unit?.name` — but `parseScaleBarcode()` never returns a `unit` key

---

## Fix

### 1. Null-safe fallback for unit/unitQuantity (paths 2, 4)

```typescript
// Before (crashes)
product.unit_id   = result.unit.id;
product.unit_name = result.unit.name;
product.unit_price = result.unitQuantity.sale_price;

// After (safe)
const uq   = result.unitQuantity || (result.product.unit_quantities && result.product.unit_quantities[0]);
const unit = result.unit || (uq && uq.unit);

product.unit_id     = unit?.id || uq?.unit_id;
product.unit_price  = uq?.sale_price;
product.price_gross = uq?.sale_price_gross;
product.price_net   = uq?.sale_price_net;
product.unit_name   = unit?.name || '';
```

### 2. Stock validation enforcement

```typescript
// Before
product.name     = result.product.name;
product.id       = result.product.id;
// ... stock_management and type missing ...

// After
product.stock_management = result.product.stock_management;
product.type             = result.product.type;
```

This ensures `ProductQuantityPromise` correctly blocks zero/insufficient stock products added via barcode scan — matching the behavior of products added via normal search.

### 3. Scale notification unit fix

```typescript
// Before — always 'kg'
const unitName = scaleData.unit?.name || 'kg';

// After — uses actual matched unit
const unitName = result.unit?.name || (uq && uq.unit && uq.unit.name) || '';
```

And price-based scale calculation was simplified to use the already-resolved `uq`:

```typescript
// Before
const unitPrice = result.product.selectedUnitQuantity?.sale_price || 
                 result.product.unit_quantities[0]?.sale_price || 0;

// After
const unitPrice = uq?.sale_price || 0;
```

---

## Testing

1. **Path 2 (procurement barcode):** Scan a barcode from a procurement product → should add to cart without crash
2. **Path 4 (direct product barcode):** Paste/scan a product's own `barcode` field → should add to cart without crash
3. **Zero stock product:** Scan a product with 0 quantity → should show "Unable to add the product, there is not enough stock" error
4. **Scale barcode:** Scan a weight scale barcode → notification should show correct unit name (not hardcoded 'kg')
5. **Path 3 (unit quantity barcode):** Existing working path should continue working unchanged