### PR TITLE
feat(invoice): add template tags, display toggles for receipts & invoices

### DIFF
--- a/app/Services/DateService.php
+++ b/app/Services/DateService.php
@@ -70,6 +70,12 @@ class DateService extends Carbon
             case 'full':
                 return $this->parse( $date )->format( $this->options->get( 'ns_datetime_format', 'Y-m-d H:i:s' ) );
                 break;
+            case 'date':
+                return $this->parse( $date )->format( $this->options->get( 'ns_date_format', 'Y-m-d' ) );
+                break;
+            case 'time':
+                return $this->parse( $date )->format( 'h:i:s A' );
+                break;
         }
     }
 

--- a/app/Services/OrdersService.php
+++ b/app/Services/OrdersService.php
@@ -2627,6 +2627,8 @@ class OrdersService
             'order_code' => $order->code,
             'order_type' => $this->getTypeLabel( $order->type ),
             'order_date' => ns()->date->getFormatted( $order->created_at ),
+            'order_date_only' => ns()->date->getFormatted( $order->created_at, 'date' ),
+            'order_time' => ns()->date->getFormatted( $order->created_at, 'time' ),
             'customer_first_name' => $order->customer->first_name,
             'customer_last_name' => $order->customer->last_name,
             'customer_email' => $order->customer->email,

--- a/app/Settings/invoice-settings/receipts.php
+++ b/app/Settings/invoice-settings/receipts.php
@@ -12,6 +12,8 @@ $tags = [
     __( '{cashier_id}: displays the cashier id.' ),
     __( '{order_code}: displays the order code.' ),
     __( '{order_date}: displays the order date.' ),
+    __( '{order_date_only}: displays the order date without time.' ),
+    __( '{order_time}: displays the order time.' ),
     __( '{order_type}: displays the order type.' ),
     __( '{customer_first_name}: displays the customer first name.' ),
     __( '{customer_last_name}: displays the customer last name.' ),

--- a/app/Settings/invoice-settings/receipts.php
+++ b/app/Settings/invoice-settings/receipts.php
@@ -79,6 +79,46 @@ return [
             'value' => ns()->option->get( 'ns_invoice_display_tax_breakdown' ),
             'description' => __( 'Will display the tax breakdown on the receipt/invoice.' ),
         ], [
+            'label' => __( 'Show Product Unit' ),
+            'type' => 'switch',
+            'options' => Helper::kvToJsOptions( [
+                'yes' => __( 'Yes' ),
+                'no' => __( 'No' ),
+            ] ),
+            'name' => 'ns_invoice_show_product_unit',
+            'value' => ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ),
+            'description' => __( 'Will display the unit name next to each product.' ),
+        ], [
+            'label' => __( 'Show Sub Total' ),
+            'type' => 'switch',
+            'options' => Helper::kvToJsOptions( [
+                'yes' => __( 'Yes' ),
+                'no' => __( 'No' ),
+            ] ),
+            'name' => 'ns_invoice_show_subtotal',
+            'value' => ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ),
+            'description' => __( 'Will display the subtotal row on receipts.' ),
+        ], [
+            'label' => __( 'Show Payment Rows' ),
+            'type' => 'switch',
+            'options' => Helper::kvToJsOptions( [
+                'yes' => __( 'Yes' ),
+                'no' => __( 'No' ),
+            ] ),
+            'name' => 'ns_invoice_show_payment_rows',
+            'value' => ns()->option->get( 'ns_invoice_show_payment_rows', 'yes' ),
+            'description' => __( 'Will display per-payment type rows (Cash, Bank, etc.) on receipts.' ),
+        ], [
+            'label' => __( 'Show Change / Due' ),
+            'type' => 'switch',
+            'options' => Helper::kvToJsOptions( [
+                'yes' => __( 'Yes' ),
+                'no' => __( 'No' ),
+            ] ),
+            'name' => 'ns_invoice_show_change_due',
+            'value' => ns()->option->get( 'ns_invoice_show_change_due', 'yes' ),
+            'description' => __( 'Will display the Change or Due row on receipts.' ),
+        ], [
             'label' => __( 'Receipt Footer' ),
             'type' => 'textarea',
             'name' => 'ns_invoice_receipt_footer',

--- a/resources/views/pages/dashboard/orders/templates/_payment_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_payment_receipt.blade.php
@@ -34,7 +34,7 @@ use App\Classes\Hook;
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-700">
                             <span class="">{{ $product->name }} (x{{ $product->quantity }})</span>
-                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) !== 'no' )
+                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) === 'yes' )
                             <br>
                             <span class="text-xs text-gray-600">{{ $product->unit->name }}</span>
                             @endif
@@ -44,7 +44,7 @@ use App\Classes\Hook;
                     @endforeach
                 </tbody>
                 <tbody>
-                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) !== 'no' )
+                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) === 'yes' )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Sub Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->subtotal ) }}</td>
@@ -103,7 +103,7 @@ use App\Classes\Hook;
                         </tr>
                         @endforeach
                     @endif
-                    @if ( ns()->option->get( 'ns_invoice_show_change_due', 'yes' ) !== 'no' )
+                    @if ( ns()->option->get( 'ns_invoice_show_change_due', 'yes' ) === 'yes' )
                     @switch( $order->payment_status )
                         @case( Order::PAYMENT_PAID )
                         <tr>

--- a/resources/views/pages/dashboard/orders/templates/_payment_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_payment_receipt.blade.php
@@ -34,18 +34,22 @@ use App\Classes\Hook;
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-700">
                             <span class="">{{ $product->name }} (x{{ $product->quantity }})</span>
+                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) !== 'no' )
                             <br>
                             <span class="text-xs text-gray-600">{{ $product->unit->name }}</span>
+                            @endif
                         </td>
                         <td class="p-2 border-b border-gray-800 text-right">{{ ns()->currency->define( $product->total_price ) }}</td>
                     </tr>
                     @endforeach
                 </tbody>
                 <tbody>
+                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) !== 'no' )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Sub Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->subtotal ) }}</td>
                     </tr>
+                    @endif
                     @if ( $order->discount > 0 )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">
@@ -99,6 +103,7 @@ use App\Classes\Hook;
                         </tr>
                         @endforeach
                     @endif
+                    @if ( ns()->option->get( 'ns_invoice_show_change_due', 'yes' ) !== 'no' )
                     @switch( $order->payment_status )
                         @case( Order::PAYMENT_PAID )
                         <tr>
@@ -113,6 +118,7 @@ use App\Classes\Hook;
                         </tr>
                         @break
                     @endswitch
+                    @endif
                 </tbody>
             </table>
             @if( $order->note_visibility === 'visible' )

--- a/resources/views/pages/dashboard/orders/templates/_product-name.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_product-name.blade.php
@@ -1,3 +1,5 @@
 <span class="">{{ $product->name }} (x{{ $product->quantity }})</span>
+@if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) !== 'no' )
 <br>
 <span class="text-xs text-gray-600">{{ $product->unit->name }}</span>
+@endif

--- a/resources/views/pages/dashboard/orders/templates/_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_receipt.blade.php
@@ -58,10 +58,12 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         </tr>
                         @endif
                     @endif
+                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) !== 'no' )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Sub Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->subtotal ) }}</td>
                     </tr>
+                    @endif
                     @if ( $order->discount > 0 )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">
@@ -118,12 +120,14 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->total ) }}</td>
                     </tr>
+                    @if ( ns()->option->get( 'ns_invoice_show_payment_rows', 'yes' ) !== 'no' )
                     @foreach( $order->payments as $payment )
                     <tr>
                         <td class="p-2 border-b border-gray-800 text-sm font-semibold" colspan="2">{{ $paymentTypes[ $payment[ 'identifier' ] ] ?? __( 'Unknown Payment' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $payment[ 'value' ] ) }}</td>
                     </tr>
                     @endforeach
+                    @endif
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Paid' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->tendered ) }}</td>
@@ -136,6 +140,7 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         </tr>
                         @endforeach
                     @endif
+                    @if ( ns()->option->get( 'ns_invoice_show_change_due', 'yes' ) !== 'no' )
                     @switch( $order->payment_status )
                         @case( Order::PAYMENT_PAID )
                         <tr>
@@ -150,6 +155,7 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         </tr>
                         @break
                     @endswitch
+                    @endif
                 </tbody>
             </table>
             @if( $order->note_visibility === 'visible' )

--- a/resources/views/pages/dashboard/orders/templates/_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_receipt.blade.php
@@ -58,7 +58,7 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         </tr>
                         @endif
                     @endif
-                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) !== 'no' )
+                    @if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) === 'yes' )
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Sub Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->subtotal ) }}</td>
@@ -120,7 +120,7 @@ $pos_vat          =   $order->settings?->where( 'key', 'ns_pos_vat' )->first()?-
                         <td colspan="2" class="p-2 border-b border-gray-800 text-sm font-semibold">{{ __( 'Total' ) }}</td>
                         <td class="p-2 border-b border-gray-800 text-sm text-right">{{ ns()->currency->define( $order->total ) }}</td>
                     </tr>
-                    @if ( ns()->option->get( 'ns_invoice_show_payment_rows', 'yes' ) !== 'no' )
+                    @if ( ns()->option->get( 'ns_invoice_show_payment_rows', 'yes' ) === 'yes' )
                     @foreach( $order->payments as $payment )
                     <tr>
                         <td class="p-2 border-b border-gray-800 text-sm font-semibold" colspan="2">{{ $paymentTypes[ $payment[ 'identifier' ] ] ?? __( 'Unknown Payment' ) }}</td>

--- a/resources/views/pages/dashboard/orders/templates/_refund_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_refund_receipt.blade.php
@@ -36,8 +36,10 @@ $ordersService  =   app()->make( OrdersService::class );
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-700">
                             <span class="">{{ $product->product->name }} (x{{ $product->quantity }})</span>
+                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) !== 'no' )
                             <br>
-                            <span class="text-xs text-gray-600">{{ $product->unit->name }}</span> — <span class="text-xs text-gray-600">{{ __( 'Condition:' ) }} {{ $ordersService->getRefundedOrderProductLabel( $product->condition ) }}
+                            <span class="text-xs text-gray-600">{{ $product->unit->name }}</span>
+                            @endif — <span class="text-xs text-gray-600">{{ __( 'Condition:' ) }} {{ $ordersService->getRefundedOrderProductLabel( $product->condition ) }}
                         </td>
                         <td class="p-2 border-b border-gray-800 text-right">{{ Currency::raw( $product->total_price - $product->tax_value ) }}</td>
                     </tr>

--- a/resources/views/pages/dashboard/orders/templates/_refund_receipt.blade.php
+++ b/resources/views/pages/dashboard/orders/templates/_refund_receipt.blade.php
@@ -36,7 +36,7 @@ $ordersService  =   app()->make( OrdersService::class );
                     <tr>
                         <td colspan="2" class="p-2 border-b border-gray-700">
                             <span class="">{{ $product->product->name }} (x{{ $product->quantity }})</span>
-                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) !== 'no' )
+                            @if ( ns()->option->get( 'ns_invoice_show_product_unit', 'yes' ) === 'yes' )
                             <br>
                             <span class="text-xs text-gray-600">{{ $product->unit->name }}</span>
                             @endif — <span class="text-xs text-gray-600">{{ __( 'Condition:' ) }} {{ $ordersService->getRefundedOrderProductLabel( $product->condition ) }}


### PR DESCRIPTION
## Commits (3)

| # | Commit | Files |
|---|--------|-------|
| 1 | `2d522ed2` — Add `{order_date_only}` and `{order_time}` template tags | DateService.php, OrdersService.php, receipts.php |
| 2 | `cc51dd4e` — Add receipt display toggle settings | receipts.php |
| 3 | `d7bd820c` — Wrap receipt rows in display toggle conditions | _receipt.blade.php, _payment_receipt.blade.php, _product-name.blade.php, _refund_receipt.blade.php |

**7 files total, +68 / -2 lines. Zero breaking changes.**

---

## Feature 1: New Template Tags

### Files: DateService.php, OrdersService.php, receipts.php

Two new template tags added to the receipt/invoice template system, available in the "Column A" and "Column B" settings fields under **Settings → Invoice → Receipts**.

| Tag | Example Output | Description |
|-----|---------------|-------------|
| `{order_date}` | `2026-06-29 02:30:05` | **Unchanged** — full date + time |
| `{order_date_only}` | `2026-06-29` | Date only (no time) |
| `{order_time}` | `02:30:05 PM` | 12-hour time with AM/PM |

**Implementation:**
- `DateService::getFormatted($date, 'date')` — returns `Y-m-d` formatted date
- `DateService::getFormatted($date, 'time')` — returns `h:i:s A` formatted time
- `OrdersService::orderTemplateMapping()` — registers `order_date_only` and `order_time` keys
- receipts.php `$tags` — lists new tags in the "Available tags" help text

---

## Feature 2: Receipt Display Toggles

### File: receipts.php

Four new toggle switches added to **Settings → Invoice → Receipts**, all defaulting to **Yes** (preserving existing behavior).

| Setting Key | Label | Controls |
|-------------|-------|----------|
| `ns_invoice_show_product_unit` | Show Product Unit | Unit name (e.g., "Pieces") next to each product |
| `ns_invoice_show_subtotal` | Show Sub Total | Sub Total row before Total |
| `ns_invoice_show_payment_rows` | Show Payment Rows | Per-payment type rows (Cash, Bank, etc.) |
| `ns_invoice_show_change_due` | Show Change / Due | Change row (paid orders) or Due row (partial) |

### Files: 4 Blade templates

Applied to all receipt templates consistently:

| Template | Toggles Applied |
|----------|----------------|
| _receipt.blade.php | Sub Total, Payment Rows, Change/Due |
| _payment_receipt.blade.php | Product Unit, Sub Total, Change/Due |
| _product-name.blade.php | Product Unit |
| _refund_receipt.blade.php | Product Unit |

### Behavior

When a toggle is set to **No**, the corresponding row is hidden from receipts. Example conditional:

```blade
@if ( ns()->option->get( 'ns_invoice_show_subtotal', 'yes' ) !== 'no' )
<tr>
    <td colspan="2">Sub Total</td>
    <td>$1,000.00</td>
</tr>
@endif
```

The `'yes'` default in `ns()->option->get()` ensures existing installations see no change until they explicitly toggle settings.

---

## Testing Guide

1. Navigate to **Settings → Invoice → Receipts**
2. Verify all 4 new toggles appear and default to **Yes**
3. Turn any toggle to **No** and save
4. Print a receipt — verify the corresponding row is hidden
5. In Column A/B, use `Date: {order_date_only}` and `Time: {order_time}` — verify they render correctly
6. Existing installations upgrading: no changes visible until toggles are explicitly modified