### PR TITLE
feat(pos): add configurable default barcode type setting

### DIFF
--- a/app/Crud/ProductCrud.php
+++ b/app/Crud/ProductCrud.php
@@ -349,7 +349,7 @@ class ProductCrud extends CrudService
                                     'name' => 'barcode_type',
                                     'label' => __( 'Barcode Type' ),
                                     'validation' => 'required',
-                                    'value' => $entry->barcode_type ?? 'code128',
+                                    'value' => $entry->barcode_type ?? ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
                                 ], [
                                     'type' => 'select',
                                     'options' => Helper::kvToJsOptions( Hook::filter( 'ns-products-type', [

--- a/app/Services/DemoService.php
+++ b/app/Services/DemoService.php
@@ -134,7 +134,7 @@ class DemoService extends DemoCoreService
                     'name' => $product->name,
                     'sku' => $random,
                     'barcode' => $random,
-                    'barcode_type' => 'code128',
+                    'barcode_type' => ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
                     'category_id' => $createdCategory[ 'id' ],
                     'description' => __( 'generated' ),
                     'type' => 'dematerialized',

--- a/app/Services/ProductService.php
+++ b/app/Services/ProductService.php
@@ -268,7 +268,7 @@ class ProductService
         }
 
         if ( empty( $data[ 'barcode_type' ] ) ) {
-            $data[ 'barcode_type' ] = 'ean8';
+            $data[ 'barcode_type' ] = ns()->option->get( 'ns_pos_default_barcode_type', 'code128' );
         }
 
         if ( empty( $data[ 'barcode' ] ) ) {

--- a/app/Settings/pos/features.php
+++ b/app/Settings/pos/features.php
@@ -123,6 +123,23 @@ return [
             description: __( 'Will permanently enable barcode autofocus to ease using a barcode reader.' )
         ),
 
+        FormInput::select(
+            label: __( 'Default Barcode Type' ),
+            name: 'ns_pos_default_barcode_type',
+            options: Helper::kvToJsOptions( [
+                'code128' => __( 'Code 128' ),
+                'ean8'    => __( 'EAN 8' ),
+                'ean13'   => __( 'EAN 13' ),
+                'code39'  => __( 'Code 39' ),
+                'code11'  => __( 'Code 11' ),
+                'codabar' => __( 'Codabar' ),
+                'upca'    => __( 'UPC A' ),
+                'upce'    => __( 'UPC E' ),
+            ] ),
+            value: ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
+            description: __( 'Choose the default barcode type pre-selected when creating a new product. Defaults to Code 128 if not set.' )
+        ),
+
         FormInput::switch(
             label: __( 'Hide Exhausted Products' ),
             name: 'ns_pos_hide_exhausted_products',


### PR DESCRIPTION
## Problem

Before this PR, the default barcode type for new products was inconsistent:

| Context | Hardcoded Default |
|---------|-------------------|
| Product create/edit form (Vue frontend) | `code128` |
| `ProductService::createSimpleProduct()` (backend API) | `ean8` |
| `DemoService` (demo data generator) | `code128` |

There was no way for store administrators to change this. If you wanted all new products to default to EAN 13 or UPC A, you had to manually change it every time.

---

## Solution

A new **"Default Barcode Type"** setting in **Settings → POS → Features** lets the admin choose. The setting is read consistently in:

1. **Product create/edit form** — barcode type dropdown pre-selects the configured type
2. **Backend product creation** — `createSimpleProduct()` uses the configured type instead of hardcoded `'ean8'`
3. **Demo data generation** — generated products use the configured type

When no value is set, **Code 128** is the fallback everywhere.

---

## Files Changed

### features.php (+17 lines)

Added a `FormInput::select` field in the POS → Features settings tab:

```php
FormInput::select(
    label: __( 'Default Barcode Type' ),
    name: 'ns_pos_default_barcode_type',
    options: Helper::kvToJsOptions( [
        'code128' => __( 'Code 128' ),
        'ean8'    => __( 'EAN 8' ),
        'ean13'   => __( 'EAN 13' ),
        'code39'  => __( 'Code 39' ),
        'code11'  => __( 'Code 11' ),
        'codabar' => __( 'Codabar' ),
        'upca'    => __( 'UPC A' ),
        'upce'    => __( 'UPC E' ),
    ] ),
    value: ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
    description: __( '...' ),
),
```

The option keys match `BarcodeService` constants (`TYPE_CODE128`, `TYPE_EAN8`, etc.) for consistency.

### ProductCrud.php (line 352)

```diff
- 'value' => $entry->barcode_type ?? 'code128',
+ 'value' => $entry->barcode_type ?? ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
```

When creating a new product (`$entry` is null), the form's barcode type select now pre-selects the configured default instead of hardcoded `code128`.

### ProductService.php (line 271)

```diff
- $data[ 'barcode_type' ] = 'ean8';
+ $data[ 'barcode_type' ] = ns()->option->get( 'ns_pos_default_barcode_type', 'code128' );
```

When a product is created via API or quick-create without specifying a barcode type, the backend now uses the configured default. Previously it always used `ean8`, which meant products created through the API could get a different barcode type than those created through the UI.

### DemoService.php (line 137)

```diff
- 'barcode_type' => 'code128',
+ 'barcode_type' => ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
```

Demo products now respect the admin's preference.

---

## Setting Key

| Key | Default | Location |
|-----|---------|----------|
| `ns_pos_default_barcode_type` | `code128` | Settings → POS → Features |

Stored in `nexopos_options` table via the standard `ns()->option` service.

---

## Available Types

| Value | Label |
|-------|-------|
| `code128` | Code 128 |
| `ean8` | EAN 8 |
| `ean13` | EAN 13 |
| `code39` | Code 39 |
| `code11` | Code 11 |
| `codabar` | Codabar |
| `upca` | UPC A |
| `upce` | UPC E |

---

## Backward Compatibility

- **Existing products:** unaffected — this only changes the default for *new* products
- **Existing installations:** after upgrade, the setting defaults to `code128`. The previous `ean8` hardcode in `ProductService` is replaced with the setting, so *new* products created via API will now get `code128` instead of `ean8` by default — a minor behavioral change. Settings can be changed to `ean8` to restore old behavior
- **No migrations, no frontend build needed**

---

## Testing

1. Go to **Settings → POS → Features** → verify "Default Barcode Type" appears with "Code 128" selected
2. Change to "EAN 8" → Save
3. **Create a new product** → barcode type dropdown should pre-select "EAN 8"
4. Set the option to empty/clear → create another product → defaults to "Code 128"
5. Generate demo data → verify products get the configured barcode type
6. Create a product via `POST /api/products` without specifying `barcode_type` → verify it uses the configured default