### PR TITLE
feat(pos): Add COGS display in POS cart with configurable markup

### DIFF
--- a/app/Http/Controllers/Dashboard/OrdersController.php
+++ b/app/Http/Controllers/Dashboard/OrdersController.php
@@ -159,14 +159,13 @@ class OrdersController extends DashboardController
         $marketplaceConnected = false;
 
         /**
-         * if the barcode reader type is set to wireless, we'll check if the system is 
-         * connected to my.nexopos.com as the wireless barcode relies 
+         * if the barcode reader type is set to wireless, we'll check if the system is
+         * connected to my.nexopos.com as the wireless barcode relies
          * on the socket feature provided by the platform.
          */
         if ( ns()->option->get( 'ns_pos_barcode_reader_type' ) === 'wireless' ) {
             $marketplaceConnected = $this->marketplaceService->testConnection();
         }
-
 
         /**
          * let's inject the necessary dependency
@@ -218,6 +217,8 @@ class OrdersController extends DashboardController
                 'ns_pos_show_preview_pinned_products' => ns()->option->get( 'ns_pos_show_preview_pinned_products', 'no' ) === 'yes' ? true : false,
                 'ns_pos_enable_pinned_products' => ns()->option->get( 'ns_pos_enable_pinned_products', 'no' ) === 'yes' ? true : false,
                 'ns_pos_barcode_reader_type' => ns()->option->get( 'ns_pos_barcode_reader_type' ),
+                'ns_pos_show_cogs' => ns()->option->get( 'ns_pos_show_cogs', 'no' ) === 'yes' ? true : false,
+                'ns_pos_cogs_markup_percentage' => (float) ns()->option->get( 'ns_pos_cogs_markup_percentage', 0 ),
                 'mynexopos_access_token' => ns()->option->get( 'mynexopos_access_token' ),
             ] ),
             'urls' => [

--- a/app/Settings/pos/features.php
+++ b/app/Settings/pos/features.php
@@ -128,13 +128,13 @@ return [
             name: 'ns_pos_default_barcode_type',
             options: Helper::kvToJsOptions( [
                 'code128' => __( 'Code 128' ),
-                'ean8'    => __( 'EAN 8' ),
-                'ean13'   => __( 'EAN 13' ),
-                'code39'  => __( 'Code 39' ),
-                'code11'  => __( 'Code 11' ),
+                'ean8' => __( 'EAN 8' ),
+                'ean13' => __( 'EAN 13' ),
+                'code39' => __( 'Code 39' ),
+                'code11' => __( 'Code 11' ),
                 'codabar' => __( 'Codabar' ),
-                'upca'    => __( 'UPC A' ),
-                'upce'    => __( 'UPC E' ),
+                'upca' => __( 'UPC A' ),
+                'upce' => __( 'UPC E' ),
             ] ),
             value: ns()->option->get( 'ns_pos_default_barcode_type', 'code128' ),
             description: __( 'Choose the default barcode type pre-selected when creating a new product. Defaults to Code 128 if not set.' )
@@ -225,6 +225,24 @@ return [
                 'wireless' => __( 'Wireless' ),
             ] ),
             value: ns()->option->get( 'ns_pos_barcode_reader_type', 'regular' ),
-        )
+        ),
+
+        FormInput::switch(
+            label: __( 'Show COGS' ),
+            name: 'ns_pos_show_cogs',
+            options: [
+                ['label' => __( 'Yes' ), 'value' => 'yes'],
+                ['label' => __( 'No' ), 'value' => 'no'],
+            ],
+            value: ns()->option->get( 'ns_pos_show_cogs' ),
+            description: __( 'Display the Cost of Goods Sold (COGS) for each product in the POS cart.' )
+        ),
+
+        FormInput::number(
+            label: __( 'COGS Markup Percentage' ),
+            name: 'ns_pos_cogs_markup_percentage',
+            value: ns()->option->get( 'ns_pos_cogs_markup_percentage', 0 ),
+            description: __( 'Percentage markup applied to the COGS displayed on the POS. Default is 0%.' )
+        ),
     ],
 ];

--- a/resources/ts/pages/dashboard/pos/ns-pos-cart.vue
+++ b/resources/ts/pages/dashboard/pos/ns-pos-cart.vue
@@ -35,7 +35,7 @@
                         </div>
                     </div>
 
-                    <div :product-index="index" :key="product.barcode" class="product-item flex" v-for="(product, index) of products">
+                    <div :product-index="index" :key="product.barcode" class="product-item flex group" v-for="(product, index) of products">
                         <div class="w-full lg:w-4/6 p-2 border border-l-0 border-t-0">
                             <div class="flex justify-between product-details mb-1">
                                 <h3 class="font-semibold">
@@ -52,6 +52,11 @@
                                             <i class="las la-award text-xl"></i>
                                         </a>
                                     </div>
+                                    <div class="px-1" v-if="options.ns_pos_show_cogs"> 
+                                        <a class="cursor-pointer outline-hidden border-dashed py-1 border-b border-info-secondary text-sm">
+                                            <i class="las la-coins text-xl"></i>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                             <div class="flex justify-between product-controls">
@@ -65,6 +70,9 @@
                                     </div>
                                     <div class="px-1 w-1/2 md:w-auto mb-1"> 
                                         <a v-if="allowQuantityModification( product )" @click="openDiscountPopup( product, 'product', index )" class="cursor-pointer outline-hidden border-dashed py-1 border-b border-secondary text-sm">{{ __( 'Discount' ) }} <span v-if="product.discount_type === 'percentage'">{{ product.discount_percentage }}%</span> : {{ nsCurrency( product.discount ) }}</a>
+                                    </div>
+                                    <div class="px-1 w-1/2 md:w-auto mb-1" v-if="options.ns_pos_show_cogs"> 
+                                        <span class="hidden group-hover:inline outline-hidden border-dashed py-1 border-b border-info-secondary text-sm text-info-tertiary">{{ __( 'COGS' ) }} : {{ nsCurrency( getProductCogs( product ) ) }}</span>
                                     </div>
                                     <div class="px-1 w-1/2 md:w-auto mb-1 lg:hidden"> 
                                         <a v-if="allowQuantityModification( product )" @click="changeQuantity( product, index )" class="cursor-pointer outline-hidden border-dashed py-1 border-b border-secondary text-sm">{{ __( 'Quantity' ) }}: {{ displayProductQuantity( product ) }}</a>
@@ -771,6 +779,21 @@ export default {
 
         allowQuantityModification( product ) {
             return product.product_type === 'product';
+        },
+
+        /**
+         * Calculate COGS for a product considering the markup percentage.
+         */
+        getProductCogs( product ) {
+            const quantities = product.$quantities ? product.$quantities() : null;
+            const unitCogs = quantities?.cogs || 0;
+            const quantity = product.quantity || 0;
+            const markupPercentage = this.options.ns_pos_cogs_markup_percentage || 0;
+            
+            const baseCogs = unitCogs * quantity;
+            const markupMultiplier = 1 + ( markupPercentage / 100 );
+            
+            return baseCogs * markupMultiplier;
         },
 
         /**


### PR DESCRIPTION
## Why This Feature Matters

Many small and medium retail shops rely on **Cost of Goods Sold (COGS)** to make pricing and discount decisions at the point of sale. Currently, sales staff who only handle the POS have no way to see COGS without being granted access to the Product Inventory page — which exposes far more than just cost data.

This creates a security and workflow problem:

- **Over-permissioning** — Granting inventory access to POS-only staff just to view COGS is excessive
- **Workflow friction** — Switching away from POS to look up costs disrupts the sale
- **Discount decisions** — Staff need COGS at a glance to negotiate discounts within margin limits
- **Artificial markup** — Shop owners often want to show an adjusted (inflated) COGS to floor staff to protect margins

This feature solves all of these by displaying COGS directly in the POS cart — **disabled by default**, with a configurable markup percentage.

---

## Changes Summary

### 3 files changed, +42 net lines

| File | Change |
|---|---|
| `app/Settings/pos/features.php` | Added 2 new POS settings: `ns_pos_show_cogs` (toggle) and `ns_pos_cogs_markup_percentage` (number, default 0) |
| `app/Http/Controllers/Dashboard/OrdersController.php` | Pass new settings to POS frontend config |
| `resources/ts/pages/dashboard/pos/ns-pos-cart.vue` | Added COGS coin icon on each cart row + inline COGS value revealed on hover |

### How It Works

1. **Enable** → Go to **Settings → POS → Features**, set "Show COGS" to **Yes**
2. **Optional Markup** → Set a "COGS Markup Percentage" (e.g. `20` → COGS shown at 120% of actual)
3. **In POS** → Each cart item shows a coins icon next to the delete button
4. **View COGS** → Hover anywhere on the product row to reveal `COGS: $X.XX` on the controls line
5. **Calculation** → `unit_cogs × quantity × (1 + markup_percentage / 100)`

### Design Decisions

- **Disabled by default** — No impact on existing users
- **Instant visibility** — COGS appears inline via CSS `group-hover`, no delayed tooltip
- **No title crowding** — COGS text renders on the product-controls row (Price/Discount/Quantity line), not the product name line
- **Icon stays on title line** — Coin icon sits beside delete and wholesale toggle icons
- **Zero layout shift** — COGS text is `hidden` in document flow, shown via `group-hover:inline`

---

## Testing Instructions

1. Go to `/dashboard/settings/pos?tab=features`
2. Enable **Show COGS** → Yes
3. Optionally set a **COGS Markup Percentage** (e.g. `10`)
4. Go to POS → add products to the cart
5. Hover over any cart item → COGS value appears instantly on second line
6. Hover away → COGS hides

---

## Cart Row Layout

```
Product Name — Piece            [delete] [wholesale] [cogs]
Price: $10  Discount: $0  COGS: $5.50
```
