### PR TITLE
fix: use Laravel translation helper when refreshing register

### DIFF
--- a/app/Services/CashRegistersService.php
+++ b/app/Services/CashRegistersService.php
@@ -308,7 +308,7 @@ class CashRegistersService
 
         return [
             'status' => 'success',
-            'message' => _( 'The register has been successfully refreshed.' ),
+            'message' => __( 'The register has been successfully refreshed.' ),
         ];
     }
 


### PR DESCRIPTION
### Summary

In `app/Services/CashRegistersService.php`, `refreshRegister()` used the gettext alias `_()` rather than Laravel's translation helper `__()`.

### Impact

In environments where the PHP `gettext` extension is not enabled or mapped, invoking `refreshRegister()` (such as when deleting orders associated with cash registers in `CreateOrderOnRegister`) threw an uncaught error:
```
Call to undefined function App\Services\_()
```

### Solution

Replaced `_()` with `__()` to match the rest of the codebase and Laravel standard helper conventions.

### Tests Run

- PHP syntax check: `php -l app/Services/CashRegistersService.php` (no syntax errors)
- Cash register test suite: `CreateTestDatabaseSQLite`, `HardResetTest`, `CreateTaxGroupTest`, `CreateCustomerGroupTest`, `CreateUnitGroupTest`, `CreateCategoryTest`, `CreateProductTest`, `CreateRegisterTest`, `CashRegisterActionsTest`, `CreateOrderOnRegister` (28 tests, 180 assertions, all passing)