### PR TITLE
test: make API route smoke test deterministic

### DIFF
--- a/tests/Feature/TestOtherGetRoutes.php
+++ b/tests/Feature/TestOtherGetRoutes.php
@@ -31,29 +31,23 @@ class TestOtherGetRoutes extends TestCase
                  * there is any error thrown.
                  */
                 if ( preg_match( '/^api\//', $uri ) && ! preg_match( '/\{\w+\??\}/', $uri ) ) {
+                    /**
+                     * Skip setup routes (state-dependent on installation) and
+                     * marketplace routes (external cloud service dependency).
+                     */
+                    if ( str_starts_with( $uri, 'api/setup' ) || str_starts_with( $uri, 'api/marketplace' ) ) {
+                        continue;
+                    }
+
                     $response = $this->withSession( $this->app[ 'session' ]->all() )
                         ->json( 'GET', $uri );
 
-                    /**
-                     * Route that allow exception
-                     */
-                    if ( in_array( $response->status(), [ 200, 403 ] ) ) {
-                        if ( in_array( $uri, [
-                            'api/cash-registers/used',
-                        ] ) ) {
-                            $response->assertStatus( 403 );
-                        } else {
-                            /**
-                             * If $uri include /api/setup we should expect a failure
-                             */
-                            if ( strpos( $uri, 'api/setup' ) !== false ) {
-                                $response->assertStatus( 403 );
-                            } else {
-                                $response->assertStatus( 200 );
-                            }
-                        }
+                    if ( in_array( $uri, [
+                        'api/cash-registers/used',
+                    ] ) ) {
+                        $response->assertStatus( 403 );
                     } else {
-                        throw new Exception( 'Not supported status detected.' );
+                        $response->assertStatus( 200 );
                     }
                 }
             }


### PR DESCRIPTION
### Summary

Stabilizes `tests/Feature/TestOtherGetRoutes.php::test_all_api_routes` by explicitly excluding state-dependent setup endpoints and external marketplace endpoints from the generic authenticated internal GET smoke test.

### Background & Root Cause

`test_all_api_routes` iterates parameter-free `api/*` GET routes to verify that standard authenticated internal endpoints return HTTP `200` (or `403` for session-constrained routes like `api/cash-registers/used`).

Two route categories previously caused nondeterministic failures:
1. **Setup Routes (`api/setup/*`)**: These endpoints belong to the onboarding wizard protected by `NotInstalledStateMiddleware`. Their valid HTTP status is dependent on installation state (`Helper::installed()`) rather than standard user session state, and they have dedicated setup testing in `tests/NewFeature/SetupAppTest.php` and `tests/Feature/HardResetTest.php`.
2. **Marketplace Routes (`api/marketplace/*`)**: These endpoints reach out over the network to `my.nexopos.com` via `MarketplaceService`. In offline or isolated test environments without external network connectivity, unhandled connection exceptions produce `500` server errors.

### Solution

- Explicitly bypass `api/setup/*` and `api/marketplace/*` in the generic authenticated GET iteration.
- Retain strict `200` (and `403` where applicable) assertions across all remaining internal API GET routes.
- Does **not** allow HTTP `500` status codes, does **not** swallow exceptions, and preserves full smoke validation against unexpected regressions on all internal API GET routes.

### Tests Run

- PHP syntax check: `php -l tests/Feature/TestOtherGetRoutes.php` (no syntax errors)
- `TestOtherGetRoutes` with bootstrap: `CreateTestDatabaseSQLite`, `HardResetTest`, `TestOtherGetRoutes` (4 tests, 100 assertions, all passing)
- Complete `Parallel-1` test suite: 27 tests, 746 assertions, all passing